### PR TITLE
Exclude .MD files from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ---
+exclude: "^.*\\.md$"
 repos:
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.1.0


### PR DESCRIPTION
Several pre-commit hooks modify Markdown files, and these hooks won't run when Markdown is direct-edited via the GitHub UI.  Just ignore Markdown to avoid unexpected diffs when pre-commit hooks are applied later on.