### PR TITLE
Use `pre-commit` consistently

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,14 +25,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8 mock pytest
+          python -m pip install flake8 mock pre-commit pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Lint with flake8
+      - name: Lint with pre-commit
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # Use pre-commit so code quality tools are applied consistently @ commit time and in CI
+          pre-commit run --all-files
       - name: Test with pytest
         run: |
           pytest


### PR DESCRIPTION
Use `pre-commit` in CI checks to be consistent with options applied at commit time.